### PR TITLE
Add teacher-only admin mode for activity registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,13 @@
 # Mergington High School Activities API
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+A super simple FastAPI application that allows everyone to view activities,
+while only teachers can register and unregister students.
 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login for administrative actions
+- Register and unregister students (teacher-only)
 
 ## Getting Started
 
@@ -30,7 +32,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/auth/login`                                                     | Verify teacher credentials (Basic auth required)                    |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student for an activity (teacher-only)                   |
+| DELETE | `/activities/{activity_name}/unregister?email=student@...`        | Unregister a student from an activity (teacher-only)                |
 
 ## Data Model
 
@@ -47,4 +51,6 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Activity data is stored in memory, which means participant changes reset when the server restarts.
+
+Teacher credentials are stored in `teachers.json` and used by the backend for Basic authentication.

--- a/src/app.py
+++ b/src/app.py
@@ -1,23 +1,57 @@
 """
 High School Management System API
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+A super simple FastAPI application that allows students to view activities,
+while only teachers can register or unregister students.
 """
 
-from fastapi import FastAPI, HTTPException
+import json
+import os
+import secrets
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+security = HTTPBasic()
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_teachers() -> dict:
+    teachers_file = current_dir / "teachers.json"
+    with teachers_file.open("r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    teachers = data.get("teachers", {})
+    if not teachers:
+        raise RuntimeError("No teachers configured in teachers.json")
+    return teachers
+
+
+teachers = load_teachers()
+
+
+def require_teacher(credentials: HTTPBasicCredentials = Depends(security)) -> str:
+    username = credentials.username
+    password = credentials.password
+
+    expected_password = teachers.get(username)
+    if expected_password is None:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    if not secrets.compare_digest(password, expected_password):
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    return username
 
 # In-memory activity database
 activities = {
@@ -88,8 +122,17 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/login")
+def login_teacher(username: str = Depends(require_teacher)):
+    return {"message": f"Logged in as {username}", "teacher": username}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    username: str = Depends(require_teacher),
+):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -107,11 +150,15 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {"message": f"{username} signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    username: str = Depends(require_teacher),
+):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -129,4 +176,4 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Remove student
     activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    return {"message": f"{username} unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,55 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userIcon = document.getElementById("user-icon");
+  const authPanel = document.getElementById("auth-panel");
+  const authButton = document.getElementById("auth-button");
+  const authStatus = document.getElementById("auth-status");
+  const teacherOnlyNote = document.getElementById("teacher-only-note");
+  const signupContainer = document.getElementById("signup-container");
+
+  let teacherAuth = localStorage.getItem("teacherAuth") || "";
+
+  function getAuthHeaders() {
+    return teacherAuth ? { Authorization: teacherAuth } : {};
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function setTeacherUI() {
+    const isTeacher = Boolean(teacherAuth);
+    signupForm.classList.toggle("hidden", !isTeacher);
+    teacherOnlyNote.classList.toggle("hidden", isTeacher);
+    authButton.textContent = isTeacher ? "Logout" : "Teacher Login";
+    authStatus.textContent = isTeacher
+      ? "Logged in as teacher"
+      : "Not logged in";
+    signupContainer.querySelector("h3").textContent = isTeacher
+      ? "Register Student for an Activity"
+      : "Teacher Actions";
+  }
+
+  function promptForCredentials() {
+    const username = window.prompt("Teacher username:");
+    if (!username) {
+      return null;
+    }
+
+    const password = window.prompt("Teacher password:");
+    if (!password) {
+      return null;
+    }
+
+    return btoa(`${username}:${password}`);
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +61,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
+
+      const isTeacher = Boolean(teacherAuth);
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +83,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacher
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,32 +137,22 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -124,37 +171,73 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userIcon.addEventListener("click", () => {
+    authPanel.classList.toggle("hidden");
+  });
+
+  authButton.addEventListener("click", async () => {
+    if (teacherAuth) {
+      teacherAuth = "";
+      localStorage.removeItem("teacherAuth");
+      setTeacherUI();
+      fetchActivities();
+      showMessage("Logged out.", "info");
+      return;
+    }
+
+    const encodedCredentials = promptForCredentials();
+    if (!encodedCredentials) {
+      return;
+    }
+
+    const authHeader = `Basic ${encodedCredentials}`;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "GET",
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed.", "error");
+        return;
+      }
+
+      teacherAuth = authHeader;
+      localStorage.setItem("teacherAuth", teacherAuth);
+      setTeacherUI();
+      fetchActivities();
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Login failed. Please try again.", "error");
+    }
+  });
+
   // Initialize app
+  setTeacherUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,13 @@
   </head>
   <body>
     <header>
+      <button id="user-icon" class="user-icon" type="button" aria-label="Teacher account menu">👤</button>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-panel" class="auth-panel hidden">
+        <button id="auth-button" type="button">Teacher Login</button>
+        <span id="auth-status" class="auth-status">Not logged in</span>
+      </div>
     </header>
 
     <main>
@@ -23,6 +28,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-only-note" class="info-message hidden">
+          Teacher mode is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,40 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.user-icon {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background-color: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+}
+
+.user-icon:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.auth-panel {
+  margin-top: 15px;
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.auth-status {
+  font-size: 14px;
+  color: #e8eaf6;
 }
 
 main {
@@ -128,6 +163,15 @@ section h3 {
 .participants-section p {
   color: #777;
   font-style: italic;
+}
+
+.info-message {
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 4px;
+  background-color: #fff8e1;
+  border: 1px solid #ffe082;
+  color: #795548;
 }
 
 .form-group {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": {
+    "mrs.smith": "mergington123",
+    "mr.johnson": "classroom456"
+  }
+}


### PR DESCRIPTION
## Summary
Implements Issue #5 by introducing a teacher-only admin mode for student registration/unregistration actions.

### What changed
- Added teacher credentials file: `src/teachers.json`
- Added backend teacher auth using HTTP Basic in `src/app.py`
- Added `GET /auth/login` endpoint for credential verification
- Protected signup/unregister endpoints so only logged-in teachers can use them
- Added top-right user icon and login panel in `src/static/index.html`
- Implemented login/logout UI flow and teacher-only action visibility in `src/static/app.js`
- Added styling for auth controls in `src/static/styles.css`
- Updated API docs in `src/README.md`

## Behavior
- Students can still view activities and participants
- Only teachers can register or unregister students

Fixes #5